### PR TITLE
Update version, for pushing to shinken.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "retention-mongodb",
   "types": ["module"],
-  "version": "1.4.2",
+  "version": "1.4.3",
   "homepage": "http://github.com/shinken-monitoring/mod-retention-mongodb",
   "author": "Jean Gabès",
   "description": "Module for loading/saving retention data from a mongodb cluster",


### PR DESCRIPTION
It's been a long time since this module was last updated on shinken.io.
The currently published version does not work with the version of pymongo recommended for use with webui2 (https://github.com/shinken-monitoring/mod-retention-mongodb/issues/8).

Would you please be so kind as to release a new version on shinken.io ?
For this, I just suggest you change the version number.