### PR TITLE
Fix: use max_workers and added worker timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.ropeproject
 *~

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "retention-mongodb",
   "types": ["module"],
-  "version": "1.4.3",
+  "version": "1.4.4",
   "homepage": "http://github.com/shinken-monitoring/mod-retention-mongodb",
   "author": "Jean Gabès",
   "description": "Module for loading/saving retention data from a mongodb cluster",


### PR DESCRIPTION
This patch forces the module to take into account the `max_workers` parameters.

The previous implementation spawned as much workers as the machine's cores using the `multiprocessing` library. The main issue is that the first operation done by `multiprocessing` when spawning a `Process` is a `fork()` system call. The module being internal to the scheduler,
it's the scheduler itself that is forked. With big configurations, the memory consumption is large enough to crash the whole machine.

The number of workers is now controlled by the `max_workers` parameter which was not used before.

The other fix is the inclusion of a `worker_timeout` parameter.

The previous implementation was waiting for the spawned workers to join 30 seconds, and was simply exiting afterwards if the job wasn't finished. Still with big configurations, if the MongoDB server does not
finish to handle queries quick enough, stalled scheduler processes (spawned workers) can remain.

With this patch, the scheduler waits for `worker_timeout` seconds, and kills the remaining jobs and raises an error in the logs.

Setting `worker_timeout` to `0` forces the scheduler to wait for all children to finish before going further.